### PR TITLE
bugfix:network:equality by ip&mask not string

### DIFF
--- a/net/ip.go
+++ b/net/ip.go
@@ -236,7 +236,17 @@ func (n Network) LeastCommonBitPosition(n1 Network) (uint, error) {
 
 // Equal is the equality test for 2 networks.
 func (n Network) Equal(n1 Network) bool {
-	return n.String() == n1.String()
+	if len(n.Number) != len(n1.Number) || len(n.Mask) != len(n1.Mask) {
+		return false
+	}
+
+	for i := range n.Number {
+		if n.Mask[i] != n1.Mask[i] || (n.Number[i]&n.Mask[i]) != (n1.Number[i]&n1.Mask[i]) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (n Network) String() string {

--- a/net/ip_test.go
+++ b/net/ip_test.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"fmt"
 	"math"
 	"net"
 	"testing"
@@ -260,12 +261,18 @@ func TestNetworkEqual(t *testing.T) {
 		{"192.128.0.0/24", "192.128.0.0/23", false, "IPv4 not equals"},
 		{"8000::/24", "8000::/24", true, "IPv6 equals"},
 		{"8000::/24", "8000::/23", false, "IPv6 not equals"},
+		{"82.253.252.7/14", "82.252.0.0/14", true, "overlap equals"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, ipNet1, _ := net.ParseCIDR(tc.n1)
 			_, ipNet2, _ := net.ParseCIDR(tc.n2)
-			assert.Equal(t, tc.equal, NewNetwork(*ipNet1).Equal(NewNetwork(*ipNet2)))
+			op := "="
+			if !tc.equal {
+				op = "!="
+			}
+			assert.Equal(t, tc.equal, NewNetwork(*ipNet1).Equal(NewNetwork(*ipNet2)),
+				fmt.Sprintf("%s %s %s", tc.n1, op, tc.n2))
 		})
 	}
 }

--- a/trie.go
+++ b/trie.go
@@ -208,6 +208,7 @@ func (p *prefixTrie) insert(network rnet.Network, entry RangerEntry) error {
 		p.entry = entry
 		return nil
 	}
+
 	bit, err := p.targetBitFromIP(network.Number)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hello.

Related Issues: #13 

The network compare ("82.253.252.7/14", "82.252.0.0/14") will cause the trie recursive call by the following code:

````golang
package main

import (
	"math/rand"
	"net"

	"github.com/yl2chen/cidranger"
)

func main() {
	trie := cidranger.NewPCTrieRanger()
	rand.Seed(1)

	addr := net.IP{
		82, 253, 252, 7,
	}

	mask := net.IPMask{0xff, 0xff, 0xff, 0xfc}
	err := trie.Insert(cidranger.NewBasicRangerEntry(net.IPNet{
		IP:   addr,
		Mask: mask,
	}))
	if err != nil {
		panic(err)
	}

	mask = net.IPMask{0xff, 0xfc, 0x00, 0x00}
	err = trie.Insert(cidranger.NewBasicRangerEntry(net.IPNet{
		IP:   addr,
		Mask: mask,
	}))
	if err != nil {
		panic(err)
	}
}

````

Signed-off-by: detailyang <detailyang@gmail.com>