### PR TITLE
Document how to get all entries in ranger

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ containingNetworks, err = ranger.ContainingNetworks(net.ParseIP("128.168.1.0"))
 ```
 To get all networks in ranger,
 ```go
-entries, err := ranger.CoveredNetworks(AllIPv4) // for IPv4
-entries, err := ranger.CoveredNetworks(AllIPv6) // for IPv6
+entries, err := ranger.CoveredNetworks(*AllIPv4) // for IPv4
+entries, err := ranger.CoveredNetworks(*AllIPv6) // for IPv6
 ```
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ To get all the networks given is contained in,
 ```go
 containingNetworks, err = ranger.ContainingNetworks(net.ParseIP("128.168.1.0"))
 ```
+To get all networks in ranger,
+```go
+entries, err := ranger.CoveredNetworks(AllIPv4) // for IPv4
+entries, err := ranger.CoveredNetworks(AllIPv6) // for IPv6
+```
 
 ## Benchmark
 Compare hit/miss case for IPv4/IPv6 using PC trie vs brute force implementation, Ranger is initialized with published AWS ip ranges (889 IPv4 CIDR blocks and 360 IPv6)

--- a/cidranger.go
+++ b/cidranger.go
@@ -33,8 +33,8 @@ To get a list of CIDR blocks in constructed ranger that contains IP:
 To get a list of all IPv4/IPv6 rangers respectively:
 
 			// returns []RangerEntry, error
-			entries, err := ranger.CoveredNetworks(AllIPv4)
-			entries, err := ranger.CoveredNetworks(AllIPv6)
+			entries, err := ranger.CoveredNetworks(*AllIPv4)
+			entries, err := ranger.CoveredNetworks(*AllIPv6)
 
 */
 package cidranger

--- a/cidranger.go
+++ b/cidranger.go
@@ -30,6 +30,12 @@ To get a list of CIDR blocks in constructed ranger that contains IP:
 			// returns []RangerEntry, error
 			entries, err := ranger.ContainingNetworks(net.ParseIP("192.168.0.1"))
 
+To get a list of all IPv4/IPv6 rangers respectively:
+
+			// returns []RangerEntry, error
+			entries, err := ranger.CoveredNetworks(AllIPv4)
+			entries, err := ranger.CoveredNetworks(AllIPv6)
+
 */
 package cidranger
 
@@ -43,6 +49,17 @@ var ErrInvalidNetworkInput = fmt.Errorf("Invalid network input")
 
 // ErrInvalidNetworkNumberInput is returned upon invalid network input.
 var ErrInvalidNetworkNumberInput = fmt.Errorf("Invalid network number input")
+
+// AllIPv4 is a IPv4 CIDR that contains all networks
+var AllIPv4 = parseCIDRUnsafe("0.0.0.0/0")
+
+// AllIPv6 is a IPv6 CIDR that contains all networks
+var AllIPv6 = parseCIDRUnsafe("0::0/0")
+
+func parseCIDRUnsafe(s string) *net.IPNet {
+	_, cidr, _ := net.ParseCIDR(s)
+	return cidr
+}
 
 // RangerEntry is an interface for insertable entry into a Ranger.
 type RangerEntry interface {

--- a/trie_test.go
+++ b/trie_test.go
@@ -12,6 +12,13 @@ import (
 	rnet "github.com/yl2chen/cidranger/net"
 )
 
+func getAllByVersion(version rnet.IPVersion) *net.IPNet {
+	if version == rnet.IPv6 {
+		return AllIPv6
+	}
+	return AllIPv4
+}
+
 func TestPrefixTrieInsert(t *testing.T) {
 	cases := []struct {
 		version                      rnet.IPVersion
@@ -73,6 +80,10 @@ func TestPrefixTrieInsert(t *testing.T) {
 			}
 
 			assert.Equal(t, len(tc.expectedNetworksInDepthOrder), trie.Len(), "trie size should match")
+
+			allNetworks, err := trie.CoveredNetworks(*getAllByVersion(tc.version))
+			assert.Nil(t, err)
+			assert.Equal(t, len(allNetworks), trie.Len(), "trie size should match")
 
 			walk := trie.walkDepth()
 			for _, network := range tc.expectedNetworksInDepthOrder {
@@ -203,6 +214,10 @@ func TestPrefixTrieRemove(t *testing.T) {
 			}
 
 			assert.Equal(t, len(tc.expectedNetworksInDepthOrder), trie.Len(), "trie size should match after revmoval")
+
+			allNetworks, err := trie.CoveredNetworks(*getAllByVersion(tc.version))
+			assert.Nil(t, err)
+			assert.Equal(t, len(allNetworks), trie.Len(), "trie size should match")
 
 			walk := trie.walkDepth()
 			for _, network := range tc.expectedNetworksInDepthOrder {
@@ -491,6 +506,10 @@ func TestTrieMemUsage(t *testing.T) {
 		t.Logf("Inserted All (%d networks)", trie.Len())
 		assert.Less(t, 0, trie.Len(), "Len should > 0")
 		assert.LessOrEqualf(t, trie.Len(), numIPs, "Len should <= %d", numIPs)
+
+		allNetworks, err := trie.CoveredNetworks(*getAllByVersion(rnet.IPv4))
+		assert.Nil(t, err)
+		assert.Equal(t, len(allNetworks), trie.Len(), "trie size should match")
 
 		// Remove networks.
 		_, all, _ := net.ParseCIDR("0.0.0.0/0")


### PR DESCRIPTION
Documentation + unit tests.
```go
entries, err := ranger.CoveredNetworks(*AllIPv4) // for IPv4
entries, err := ranger.CoveredNetworks(*AllIPv6) // for IPv6
````

This closes #5 