### PR TITLE
make tests run on 32-bit archs

### DIFF
--- a/trie_test.go
+++ b/trie_test.go
@@ -546,10 +546,10 @@ func GenLeafIPNet(ip net.IP) net.IPNet {
 // GenIPV4 generates an IPV4 address
 func GenIPV4() net.IP {
 	rand.Seed(time.Now().UnixNano())
-	var min, max int
-	min = 1
-	max = 4294967295
-	nn := rand.Intn(max-min) + min
+	nn := rand.Uint32()
+	if nn < 4294967295 {
+		nn++
+	}
 	ip := make(net.IP, 4)
 	binary.BigEndian.PutUint32(ip, uint32(nn))
 	return ip


### PR DESCRIPTION
On 32-bit architectures, the value of a constant used in `trie_test.go` would overflow a signed `int`:

```
$ GOARCH=386 go test -v ./...
# github.com/yl2chen/cidranger [github.com/yl2chen/cidranger.test]
./trie_test.go:551:8: constant 4294967295 overflows int
FAIL	github.com/yl2chen/cidranger [build failed]
```

 We address the issue by using an unsigned 32-bit integer type instead.