### PR TITLE
Convert IPv4 mapped IPv6 subnet masks to 4 bytes from 16 bytes (using the last 4 bytes)

### DIFF
--- a/net/ip.go
+++ b/net/ip.go
@@ -177,6 +177,7 @@ type Network struct {
 
 // NewNetwork returns Network built using given net.IPNet.
 func NewNetwork(ipNet net.IPNet) Network {
+	ipNet = getNetwork(ipNet)
 	return Network{
 		IPNet:  ipNet,
 		Number: NewNetworkNumber(ipNet.IP),
@@ -269,4 +270,13 @@ func NextIP(ip net.IP) net.IP {
 // PreviousIP returns the previous sequential ip.
 func PreviousIP(ip net.IP) net.IP {
 	return NewNetworkNumber(ip).Previous().ToIP()
+}
+
+// getNetwork converts IPv4 mapped IPv6 subnet masks to 4 bytes.
+// E.g. ::ffff:d1ad:35a7/128 get converted to 209.173.54.167/32. /128 becomes /32, /120 becomes /24 and so on.
+func getNetwork(network net.IPNet) net.IPNet {
+	if network.IP.To4() != nil && len(network.Mask) == net.IPv6len {
+		network.Mask = network.Mask[12:16]
+	}
+	return network
 }


### PR DESCRIPTION
@yl2chen 
Currently, you can't add IPv4 mapped IPv6 networks.

For example, If you try insert `::ffff:d1ad:35a7/128`, a nil network will be inserted. This uses `ipV4Ranger` (as it is stored as IPv4 address internally), but the mask isn't converted and remains 16 bytes. Hence you have something like this `209.173.53.167/128` instead of `209.173.53.167/32`.

> func (n Network) Masked(ones int) Network {
	mask := net.CIDRMask(ones, len(n.Number)*BitsPerUint32)
	return NewNetwork(net.IPNet{
		IP:   n.IP.Mask(mask),
		Mask: mask,
	})
}