### PR TITLE
performance improvement on certain operation

### DIFF
--- a/brute.go
+++ b/brute.go
@@ -43,6 +43,11 @@ func (b *bruteRanger) Insert(entry RangerEntry) error {
 	return nil
 }
 
+// MergeInsert not implement in bruteRanger
+func (b *bruteRanger) MergeInsert(_ RangerEntry) error {
+	return nil
+}
+
 // Remove removes a RangerEntry identified by given network from ranger.
 func (b *bruteRanger) Remove(network net.IPNet) (RangerEntry, error) {
 	networks, err := b.getEntriesByVersion(network.IP)

--- a/brute.go
+++ b/brute.go
@@ -118,6 +118,11 @@ func (b *bruteRanger) Len() int {
 	return len(b.ipV4Entries) + len(b.ipV6Entries)
 }
 
+// same as Len
+func (b *bruteRanger) RecalculateLen() int {
+	return len(b.ipV4Entries) + len(b.ipV6Entries)
+}
+
 func (b *bruteRanger) getEntriesByVersion(ip net.IP) (map[string]RangerEntry, error) {
 	if ip.To4() != nil {
 		return b.ipV4Entries, nil

--- a/cidranger.go
+++ b/cidranger.go
@@ -85,6 +85,7 @@ func NewBasicRangerEntry(ipNet net.IPNet) RangerEntry {
 // Ranger is an interface for cidr block containment lookups.
 type Ranger interface {
 	Insert(entry RangerEntry) error
+	MergeInsert(entry RangerEntry) error
 	Remove(network net.IPNet) (RangerEntry, error)
 	Contains(ip net.IP) (bool, error)
 	ContainingNetworks(ip net.IP) ([]RangerEntry, error)

--- a/cidranger.go
+++ b/cidranger.go
@@ -91,6 +91,7 @@ type Ranger interface {
 	ContainingNetworks(ip net.IP) ([]RangerEntry, error)
 	CoveredNetworks(network net.IPNet) ([]RangerEntry, error)
 	Len() int
+	RecalculateLen() int
 }
 
 // NewPCTrieRanger returns a versionedRanger that supports both IPv4 and IPv6

--- a/cidranger_test.go
+++ b/cidranger_test.go
@@ -182,6 +182,14 @@ func BenchmarkBruteRangerMissContainingNetworksIPv6UsingAWSRanges(b *testing.B) 
 	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620::ffff"), newBruteRanger())
 }
 
+func BenchmarkNewPathprefixTriev4(b *testing.B) {
+	benchmarkNewPathprefixTrie(b, "192.128.0.0/24")
+}
+
+func BenchmarkNewPathprefixTriev6(b *testing.B) {
+	benchmarkNewPathprefixTrie(b, "8000::/24")
+}
+
 func benchmarkContainsUsingAWSRanges(tb testing.TB, nn net.IP, ranger Ranger) {
 	configureRangerWithAWSRanges(tb, ranger)
 	for n := 0; n < tb.(*testing.B).N; n++ {
@@ -193,6 +201,19 @@ func benchmarkContainingNetworksUsingAWSRanges(tb testing.TB, nn net.IP, ranger 
 	configureRangerWithAWSRanges(tb, ranger)
 	for n := 0; n < tb.(*testing.B).N; n++ {
 		ranger.ContainingNetworks(nn)
+	}
+}
+
+func benchmarkNewPathprefixTrie(b *testing.B, net1 string) {
+	_, ipNet1, _ := net.ParseCIDR(net1)
+	ones, _ := ipNet1.Mask.Size()
+
+	n1 := rnet.NewNetwork(*ipNet1)
+	uOnes := uint(ones)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		newPathprefixTrie(n1, uOnes)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/yl2chen/cidranger
 
 go 1.13
 
-require github.com/stretchr/testify v1.4.0
+require (
+	github.com/stretchr/testify v1.6.1
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/net/ip.go
+++ b/net/ip.go
@@ -4,6 +4,7 @@ Package net provides utility functions for working with IPs (net.IP).
 package net
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -236,7 +237,7 @@ func (n Network) LeastCommonBitPosition(n1 Network) (uint, error) {
 
 // Equal is the equality test for 2 networks.
 func (n Network) Equal(n1 Network) bool {
-	return n.String() == n1.String()
+	return bytes.Equal(n.IPNet.IP, n1.IPNet.IP) && bytes.Equal(n.IPNet.Mask, n1.IPNet.Mask)
 }
 
 func (n Network) String() string {

--- a/net/ip_test.go
+++ b/net/ip_test.go
@@ -467,6 +467,14 @@ func BenchmarkNetworkContainsIPv6(b *testing.B) {
 	benchmarkNetworkContains(b, "2600:1ffe:e000::/40", "2600:1ffe:f000::")
 }
 
+func BenchmarkNetworkEqualIPv4(b *testing.B) {
+	benchmarkNetworkEqual(b, "192.128.0.0/24", "192.128.0.0/24")
+}
+
+func BenchmarkNetworkEqualIPv6(b *testing.B) {
+	benchmarkNetworkEqual(b, "8000::/24", "8000::/24")
+}
+
 func benchmarkNetworkNumberBit(b *testing.B, ip string, pos uint) {
 	nn := NewNetworkNumber(net.ParseIP(ip))
 	for n := 0; n < b.N; n++ {
@@ -488,5 +496,15 @@ func benchmarkNetworkContains(b *testing.B, cidr string, ip string) {
 	network := NewNetwork(*ipNet)
 	for n := 0; n < b.N; n++ {
 		network.Contains(nn)
+	}
+}
+
+func benchmarkNetworkEqual(b *testing.B, net1 string, net2 string) {
+	_, ipNet1, _ := net.ParseCIDR(net1)
+	_, ipNet2, _ := net.ParseCIDR(net2)
+	n1 := NewNetwork(*ipNet1)
+	n2 := NewNetwork(*ipNet2)
+	for n := 0; n < b.N; n++ {
+		n1.Equal(n2)
 	}
 }

--- a/trie.go
+++ b/trie.go
@@ -61,13 +61,12 @@ func newPrefixTree(version rnet.IPVersion) Ranger {
 }
 
 func newPathprefixTrie(network rnet.Network, numBitsSkipped uint) *prefixTrie {
-	version := rnet.IPv4
-	if len(network.Number) == rnet.IPv6Uint32Count {
-		version = rnet.IPv6
+	path := &prefixTrie{
+		children:       make([]*prefixTrie, 2, 2),
+		numBitsSkipped: numBitsSkipped,
+		numBitsHandled: 1,
+		network:        network.Masked(int(numBitsSkipped)),
 	}
-	path := newPrefixTree(version).(*prefixTrie)
-	path.numBitsSkipped = numBitsSkipped
-	path.network = network.Masked(int(numBitsSkipped))
 	return path
 }
 

--- a/trie.go
+++ b/trie.go
@@ -136,6 +136,10 @@ func (p *prefixTrie) Len() int {
 	return p.size
 }
 
+func (p *prefixTrie) RecalculateLen() int {
+	return p.recalculateLen()
+}
+
 // String returns string representation of trie, mainly for visualization and
 // debugging.
 func (p *prefixTrie) String() string {
@@ -345,6 +349,20 @@ func (p *prefixTrie) mergeChildren() bool {
 		p.entry = NewBasicRangerEntry(p.network.IPNet)
 	}
 	return true
+}
+
+func (p *prefixTrie) recalculateLen() int {
+	var count int
+	for _, child := range p.children {
+		if child != nil {
+			count += child.recalculateLen()
+		}
+	}
+
+	if p.hasEntry() {
+		count++
+	}
+	return count
 }
 
 func (p *prefixTrie) appendTrie(bit uint32, prefix *prefixTrie) {

--- a/trie_test.go
+++ b/trie_test.go
@@ -142,6 +142,7 @@ func TestPrefixTrieMergeInsert(t *testing.T) {
 		_, network, _ := net.ParseCIDR(insert)
 		trie.MergeInsert(NewBasicRangerEntry(*network))
 		fmt.Printf("%s\n\n", trie.String())
+		fmt.Printf("size : %d\n\n", trie.recalculateLen())
 	}
 }
 
@@ -158,6 +159,7 @@ func TestPrefixTrieMergeInsert2(t *testing.T) {
 		_, network, _ := net.ParseCIDR(insert)
 		trie.MergeInsert(NewBasicRangerEntry(*network))
 		fmt.Printf("%s\n\n", trie.String())
+		fmt.Printf("size : %d\n\n", trie.recalculateLen())
 	}
 }
 

--- a/trie_test.go
+++ b/trie_test.go
@@ -2,6 +2,7 @@ package cidranger
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"net"
 	"runtime"
@@ -114,6 +115,50 @@ func TestPrefixTrieString(t *testing.T) {
 | | 1--> 192.168.1.0/24 (target_pos:7:has_entry:true)
 | | | 0--> 192.168.1.0/30 (target_pos:1:has_entry:true)`
 	assert.Equal(t, expected, trie.String())
+}
+
+func TestPrefixTrieString2(t *testing.T) {
+	trie := newPrefixTree(rnet.IPv4).(*prefixTrie)
+	inserts := []string{"8.8.8.1/25", "8.8.9.1/25", "8.8.10.1/24"}
+	for _, insert := range inserts {
+		_, network, _ := net.ParseCIDR(insert)
+		trie.Insert(NewBasicRangerEntry(*network))
+		fmt.Printf("%s\n\n", trie.String())
+	}
+}
+
+func TestPrefixTrieMergeInsert(t *testing.T) {
+	trie := newPrefixTree(rnet.IPv4).(*prefixTrie)
+	inserts := []string{
+		"8.8.8.1/25",
+		"8.8.9.1/25",
+		"8.8.10.1/24",
+		"8.8.8.128/25",
+		"8.8.9.128/25",
+		"8.8.11.128/25",
+		"8.8.11.0/25",
+	}
+	for _, insert := range inserts {
+		_, network, _ := net.ParseCIDR(insert)
+		trie.MergeInsert(NewBasicRangerEntry(*network))
+		fmt.Printf("%s\n\n", trie.String())
+	}
+}
+
+func TestPrefixTrieMergeInsert2(t *testing.T) {
+	trie := newPrefixTree(rnet.IPv4).(*prefixTrie)
+	inserts := []string{
+		"8.8.8.128/29",
+		"8.8.8.128/29",
+		"8.8.9.0/24",
+		"8.8.8.0/23",
+		"8.8.9.0/24",
+	}
+	for _, insert := range inserts {
+		_, network, _ := net.ParseCIDR(insert)
+		trie.MergeInsert(NewBasicRangerEntry(*network))
+		fmt.Printf("%s\n\n", trie.String())
+	}
 }
 
 func TestPrefixTrieRemove(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -76,6 +76,11 @@ func (v *versionedRanger) Len() int {
 	return v.ipV4Ranger.Len() + v.ipV6Ranger.Len()
 }
 
+// RecalculateLen returns number of networks in ranger.
+func (v *versionedRanger) RecalculateLen() int {
+	return v.ipV4Ranger.RecalculateLen() + v.ipV6Ranger.RecalculateLen()
+}
+
 func (v *versionedRanger) getRangerForIP(ip net.IP) (Ranger, error) {
 	if ip.To4() != nil {
 		return v.ipV4Ranger, nil

--- a/version.go
+++ b/version.go
@@ -29,6 +29,16 @@ func (v *versionedRanger) Insert(entry RangerEntry) error {
 	return ranger.Insert(entry)
 }
 
+// MergeInsert inserts a RangerEntry into prefix trie, and apply merge if possible
+func (v *versionedRanger) MergeInsert(entry RangerEntry) error {
+	network := entry.Network()
+	ranger, err := v.getRangerForIP(network.IP)
+	if err != nil {
+		return err
+	}
+	return ranger.MergeInsert(entry)
+}
+
 func (v *versionedRanger) Remove(network net.IPNet) (RangerEntry, error) {
 	ranger, err := v.getRangerForIP(network.IP)
 	if err != nil {


### PR DESCRIPTION
1. include https://github.com/yl2chen/cidranger/pull/37 but remove unnecessary changes, add the benchmark on this as well.

before
```
BenchmarkNetworkEqualIPv4-16          	 5917344	       198 ns/op	      64 B/op	       6 allocs/op
BenchmarkNetworkEqualIPv6-16          	 4486786	       273 ns/op	      42 B/op	       6 allocs/op
```

after
```
BenchmarkNetworkEqualIPv4-16          	100000000	        10.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkNetworkEqualIPv6-16          	100000000	        10.9 ns/op	       0 B/op	       0 allocs/op
```

2. change **newPathprefixTrie** to not call **newPrefixTree**, save time on extra parseCIDR and NewNetwork

before
```
BenchmarkNewPathprefixTriev4-16                                    	 2731194	       440 ns/op	     288 B/op	      12 allocs/op
BenchmarkNewPathprefixTriev6-16                                    	 1610536	       743 ns/op	     456 B/op	      16 allocs/op
```

after
```
BenchmarkNewPathprefixTriev4-16                                    	13315774	        88.3 ns/op	      16 B/op	       4 allocs/op
BenchmarkNewPathprefixTriev6-16                                    	 7967464	       153 ns/op	      64 B/op	       4 allocs/op
```
