### PR TITLE
performance improvement on certain operation

### DIFF
--- a/cidranger_test.go
+++ b/cidranger_test.go
@@ -182,6 +182,14 @@ func BenchmarkBruteRangerMissContainingNetworksIPv6UsingAWSRanges(b *testing.B) 
 	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620::ffff"), newBruteRanger())
 }
 
+func BenchmarkNewPathprefixTriev4(b *testing.B) {
+	benchmarkNewPathprefixTrie(b, "192.128.0.0/24")
+}
+
+func BenchmarkNewPathprefixTriev6(b *testing.B) {
+	benchmarkNewPathprefixTrie(b, "8000::/24")
+}
+
 func benchmarkContainsUsingAWSRanges(tb testing.TB, nn net.IP, ranger Ranger) {
 	configureRangerWithAWSRanges(tb, ranger)
 	for n := 0; n < tb.(*testing.B).N; n++ {
@@ -193,6 +201,19 @@ func benchmarkContainingNetworksUsingAWSRanges(tb testing.TB, nn net.IP, ranger 
 	configureRangerWithAWSRanges(tb, ranger)
 	for n := 0; n < tb.(*testing.B).N; n++ {
 		ranger.ContainingNetworks(nn)
+	}
+}
+
+func benchmarkNewPathprefixTrie(b *testing.B, net1 string) {
+	_, ipNet1, _ := net.ParseCIDR(net1)
+	ones, _ := ipNet1.Mask.Size()
+
+	n1 := rnet.NewNetwork(*ipNet1)
+	uOnes := uint(ones)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		newPathprefixTrie(n1, uOnes)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/yl2chen/cidranger
 
 go 1.13
 
-require github.com/stretchr/testify v1.4.0
+require (
+	github.com/stretchr/testify v1.6.1
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/net/ip.go
+++ b/net/ip.go
@@ -4,6 +4,7 @@ Package net provides utility functions for working with IPs (net.IP).
 package net
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -236,7 +237,7 @@ func (n Network) LeastCommonBitPosition(n1 Network) (uint, error) {
 
 // Equal is the equality test for 2 networks.
 func (n Network) Equal(n1 Network) bool {
-	return n.String() == n1.String()
+	return bytes.Equal(n.IPNet.IP, n1.IPNet.IP) && bytes.Equal(n.IPNet.Mask, n1.IPNet.Mask)
 }
 
 func (n Network) String() string {

--- a/net/ip_test.go
+++ b/net/ip_test.go
@@ -467,6 +467,14 @@ func BenchmarkNetworkContainsIPv6(b *testing.B) {
 	benchmarkNetworkContains(b, "2600:1ffe:e000::/40", "2600:1ffe:f000::")
 }
 
+func BenchmarkNetworkEqualIPv4(b *testing.B) {
+	benchmarkNetworkEqual(b, "192.128.0.0/24", "192.128.0.0/24")
+}
+
+func BenchmarkNetworkEqualIPv6(b *testing.B) {
+	benchmarkNetworkEqual(b, "8000::/24", "8000::/24")
+}
+
 func benchmarkNetworkNumberBit(b *testing.B, ip string, pos uint) {
 	nn := NewNetworkNumber(net.ParseIP(ip))
 	for n := 0; n < b.N; n++ {
@@ -488,5 +496,15 @@ func benchmarkNetworkContains(b *testing.B, cidr string, ip string) {
 	network := NewNetwork(*ipNet)
 	for n := 0; n < b.N; n++ {
 		network.Contains(nn)
+	}
+}
+
+func benchmarkNetworkEqual(b *testing.B, net1 string, net2 string) {
+	_, ipNet1, _ := net.ParseCIDR(net1)
+	_, ipNet2, _ := net.ParseCIDR(net2)
+	n1 := NewNetwork(*ipNet1)
+	n2 := NewNetwork(*ipNet2)
+	for n := 0; n < b.N; n++ {
+		n1.Equal(n2)
 	}
 }

--- a/trie.go
+++ b/trie.go
@@ -61,13 +61,12 @@ func newPrefixTree(version rnet.IPVersion) Ranger {
 }
 
 func newPathprefixTrie(network rnet.Network, numBitsSkipped uint) *prefixTrie {
-	version := rnet.IPv4
-	if len(network.Number) == rnet.IPv6Uint32Count {
-		version = rnet.IPv6
+	path := &prefixTrie{
+		children:       make([]*prefixTrie, 2, 2),
+		numBitsSkipped: numBitsSkipped,
+		numBitsHandled: 1,
+		network:        network.Masked(int(numBitsSkipped)),
 	}
-	path := newPrefixTree(version).(*prefixTrie)
-	path.numBitsSkipped = numBitsSkipped
-	path.network = network.Masked(int(numBitsSkipped))
 	return path
 }
 


### PR DESCRIPTION
include #37 but remove unnecessary changes, add the benchmark on this as well.
before
```
BenchmarkNetworkEqualIPv4-16          	 5917344	       198 ns/op	      64 B/op	       6 allocs/op
BenchmarkNetworkEqualIPv6-16          	 4486786	       273 ns/op	      42 B/op	       6 allocs/op
```
after
```
BenchmarkNetworkEqualIPv4-16          	100000000	        10.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkNetworkEqualIPv6-16          	100000000	        10.9 ns/op	       0 B/op	       0 allocs/op
```
change newPathprefixTrie to not call newPrefixTree, save time on extra parseCIDR and NewNetwork
before
```
BenchmarkNewPathprefixTriev4-16                                    	 2731194	       440 ns/op	     288 B/op	      12 allocs/op
BenchmarkNewPathprefixTriev6-16                                    	 1610536	       743 ns/op	     456 B/op	      16 allocs/op
```
after
```
BenchmarkNewPathprefixTriev4-16                                    	13315774	        88.3 ns/op	      16 B/op	       4 allocs/op
BenchmarkNewPathprefixTriev6-16                                    	 7967464	       153 ns/op	      64 B/op	       4 allocs/op
```