### PR TITLE
Move from net to netip

### DIFF
--- a/brute_test.go
+++ b/brute_test.go
@@ -1,7 +1,7 @@
 package cidranger
 
 import (
-	"net"
+	"net/netip"
 	"sort"
 	"testing"
 
@@ -10,46 +10,38 @@ import (
 
 func TestInsert(t *testing.T) {
 	ranger := newBruteRanger().(*bruteRanger)
-	_, networkIPv4, _ := net.ParseCIDR("0.0.1.0/24")
-	_, networkIPv6, _ := net.ParseCIDR("8000::/96")
-	entryIPv4 := NewBasicRangerEntry(*networkIPv4)
-	entryIPv6 := NewBasicRangerEntry(*networkIPv6)
+	networkIPv4 := netip.MustParsePrefix("0.0.1.0/24")
+	networkIPv6 := netip.MustParsePrefix("8000::/96")
+	entryIPv4 := NewBasicRangerEntry(networkIPv4)
+	entryIPv6 := NewBasicRangerEntry(networkIPv6)
 
 	ranger.Insert(entryIPv4)
 	ranger.Insert(entryIPv6)
 
 	assert.Equal(t, 1, len(ranger.ipV4Entries))
-	assert.Equal(t, entryIPv4, ranger.ipV4Entries["0.0.1.0/24"])
+	assert.Equal(t, entryIPv4, ranger.ipV4Entries[networkIPv4])
 	assert.Equal(t, 1, len(ranger.ipV6Entries))
-	assert.Equal(t, entryIPv6, ranger.ipV6Entries["8000::/96"])
-}
-
-func TestInsertError(t *testing.T) {
-	bRanger := newBruteRanger().(*bruteRanger)
-	_, networkIPv4, _ := net.ParseCIDR("0.0.1.0/24")
-	networkIPv4.IP = append(networkIPv4.IP, byte(4))
-	err := bRanger.Insert(NewBasicRangerEntry(*networkIPv4))
-	assert.Equal(t, ErrInvalidNetworkInput, err)
+	assert.Equal(t, entryIPv6, ranger.ipV6Entries[networkIPv6])
 }
 
 func TestRemove(t *testing.T) {
 	ranger := newBruteRanger().(*bruteRanger)
-	_, networkIPv4, _ := net.ParseCIDR("0.0.1.0/24")
-	_, networkIPv6, _ := net.ParseCIDR("8000::/96")
-	_, notInserted, _ := net.ParseCIDR("8000::/96")
+	networkIPv4 := netip.MustParsePrefix("0.0.1.0/24")
+	networkIPv6 := netip.MustParsePrefix("8000::/96")
+	notInserted := netip.MustParsePrefix("8000::/96")
 
-	insertIPv4 := NewBasicRangerEntry(*networkIPv4)
-	insertIPv6 := NewBasicRangerEntry(*networkIPv6)
+	insertIPv4 := NewBasicRangerEntry(networkIPv4)
+	insertIPv6 := NewBasicRangerEntry(networkIPv6)
 
 	ranger.Insert(insertIPv4)
-	deletedIPv4, err := ranger.Remove(*networkIPv4)
+	deletedIPv4, err := ranger.Remove(networkIPv4)
 	assert.NoError(t, err)
 
 	ranger.Insert(insertIPv6)
-	deletedIPv6, err := ranger.Remove(*networkIPv6)
+	deletedIPv6, err := ranger.Remove(networkIPv6)
 	assert.NoError(t, err)
 
-	entry, err := ranger.Remove(*notInserted)
+	entry, err := ranger.Remove(notInserted)
 	assert.NoError(t, err)
 	assert.Nil(t, entry)
 
@@ -59,33 +51,23 @@ func TestRemove(t *testing.T) {
 	assert.Equal(t, 0, len(ranger.ipV6Entries))
 }
 
-func TestRemoveError(t *testing.T) {
-	r := newBruteRanger().(*bruteRanger)
-	_, invalidNetwork, _ := net.ParseCIDR("0.0.1.0/24")
-	invalidNetwork.IP = append(invalidNetwork.IP, byte(4))
-
-	_, err := r.Remove(*invalidNetwork)
-	assert.Equal(t, ErrInvalidNetworkInput, err)
-}
-
 func TestContains(t *testing.T) {
 	r := newBruteRanger().(*bruteRanger)
-	_, network, _ := net.ParseCIDR("0.0.1.0/24")
-	_, network1, _ := net.ParseCIDR("8000::/112")
-	r.Insert(NewBasicRangerEntry(*network))
-	r.Insert(NewBasicRangerEntry(*network1))
+	network := netip.MustParsePrefix("0.0.1.0/24")
+	network1 := netip.MustParsePrefix("8000::/112")
+	r.Insert(NewBasicRangerEntry(network))
+	r.Insert(NewBasicRangerEntry(network1))
 
 	cases := []struct {
-		ip       net.IP
+		ip       netip.Addr
 		contains bool
 		err      error
 		name     string
 	}{
-		{net.ParseIP("0.0.1.255"), true, nil, "IPv4 should contain"},
-		{net.ParseIP("0.0.0.255"), false, nil, "IPv4 houldn't contain"},
-		{net.ParseIP("8000::ffff"), true, nil, "IPv6 shouldn't contain"},
-		{net.ParseIP("8000::1:ffff"), false, nil, "IPv6 shouldn't contain"},
-		{append(net.ParseIP("8000::1:ffff"), byte(0)), false, ErrInvalidNetworkInput, "Invalid IP"},
+		{netip.MustParseAddr("0.0.1.255"), true, nil, "IPv4 should contain"},
+		{netip.MustParseAddr("0.0.0.255"), false, nil, "IPv4 shouldn't contain"},
+		{netip.MustParseAddr("8000::ffff"), true, nil, "IPv6 shouldn't contain"},
+		{netip.MustParseAddr("8000::1:ffff"), false, nil, "IPv6 shouldn't contain"},
 	}
 
 	for _, tc := range cases {
@@ -103,31 +85,30 @@ func TestContains(t *testing.T) {
 
 func TestContainingNetworks(t *testing.T) {
 	r := newBruteRanger().(*bruteRanger)
-	_, network1, _ := net.ParseCIDR("0.0.1.0/24")
-	_, network2, _ := net.ParseCIDR("0.0.1.0/25")
-	_, network3, _ := net.ParseCIDR("8000::/112")
-	_, network4, _ := net.ParseCIDR("8000::/113")
-	entry1 := NewBasicRangerEntry(*network1)
-	entry2 := NewBasicRangerEntry(*network2)
-	entry3 := NewBasicRangerEntry(*network3)
-	entry4 := NewBasicRangerEntry(*network4)
+	network1 := netip.MustParsePrefix("0.0.1.0/24")
+	network2 := netip.MustParsePrefix("0.0.1.0/25")
+	network3 := netip.MustParsePrefix("8000::/112")
+	network4 := netip.MustParsePrefix("8000::/113")
+	entry1 := NewBasicRangerEntry(network1)
+	entry2 := NewBasicRangerEntry(network2)
+	entry3 := NewBasicRangerEntry(network3)
+	entry4 := NewBasicRangerEntry(network4)
 	r.Insert(entry1)
 	r.Insert(entry2)
 	r.Insert(entry3)
 	r.Insert(entry4)
 	cases := []struct {
-		ip                 net.IP
+		ip                 netip.Addr
 		containingNetworks []RangerEntry
 		err                error
 		name               string
 	}{
-		{net.ParseIP("0.0.1.255"), []RangerEntry{entry1}, nil, "IPv4 should contain"},
-		{net.ParseIP("0.0.1.127"), []RangerEntry{entry1, entry2}, nil, "IPv4 should contain both"},
-		{net.ParseIP("0.0.0.127"), []RangerEntry{}, nil, "IPv4 should contain none"},
-		{net.ParseIP("8000::ffff"), []RangerEntry{entry3}, nil, "IPv6 should constain"},
-		{net.ParseIP("8000::7fff"), []RangerEntry{entry3, entry4}, nil, "IPv6 should contain both"},
-		{net.ParseIP("8000::1:7fff"), []RangerEntry{}, nil, "IPv6 should contain none"},
-		{append(net.ParseIP("8000::1:7fff"), byte(0)), nil, ErrInvalidNetworkInput, "Invalid IP"},
+		{netip.MustParseAddr("0.0.1.255"), []RangerEntry{entry1}, nil, "IPv4 should contain"},
+		{netip.MustParseAddr("0.0.1.127"), []RangerEntry{entry1, entry2}, nil, "IPv4 should contain both"},
+		{netip.MustParseAddr("0.0.0.127"), []RangerEntry{}, nil, "IPv4 should contain none"},
+		{netip.MustParseAddr("8000::ffff"), []RangerEntry{entry3}, nil, "IPv6 should constain"},
+		{netip.MustParseAddr("8000::7fff"), []RangerEntry{entry3, entry4}, nil, "IPv6 should contain both"},
+		{netip.MustParseAddr("8000::1:7fff"), []RangerEntry{}, nil, "IPv6 should contain none"},
 	}
 
 	for _, tc := range cases {
@@ -151,17 +132,16 @@ func TestCoveredNetworks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ranger := newBruteRanger()
 			for _, insert := range tc.inserts {
-				_, network, _ := net.ParseCIDR(insert)
-				err := ranger.Insert(NewBasicRangerEntry(*network))
+				network := netip.MustParsePrefix(insert)
+				err := ranger.Insert(NewBasicRangerEntry(network))
 				assert.NoError(t, err)
 			}
+
 			var expectedEntries []string
-			for _, network := range tc.networks {
-				expectedEntries = append(expectedEntries, network)
-			}
+			expectedEntries = append(expectedEntries, tc.networks...)
 			sort.Strings(expectedEntries)
-			_, snet, _ := net.ParseCIDR(tc.search)
-			networks, err := ranger.CoveredNetworks(*snet)
+			snet := netip.MustParsePrefix(tc.search)
+			networks, err := ranger.CoveredNetworks(snet)
 			assert.NoError(t, err)
 
 			var results []string

--- a/cidranger.go
+++ b/cidranger.go
@@ -41,14 +41,14 @@ package cidranger
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 )
 
 // ErrInvalidNetworkInput is returned upon invalid network input.
-var ErrInvalidNetworkInput = fmt.Errorf("Invalid network input")
+var ErrInvalidNetworkInput = fmt.Errorf("invalid network input")
 
 // ErrInvalidNetworkNumberInput is returned upon invalid network input.
-var ErrInvalidNetworkNumberInput = fmt.Errorf("Invalid network number input")
+var ErrInvalidNetworkNumberInput = fmt.Errorf("invalid network number input")
 
 // AllIPv4 is a IPv4 CIDR that contains all networks
 var AllIPv4 = parseCIDRUnsafe("0.0.0.0/0")
@@ -56,39 +56,39 @@ var AllIPv4 = parseCIDRUnsafe("0.0.0.0/0")
 // AllIPv6 is a IPv6 CIDR that contains all networks
 var AllIPv6 = parseCIDRUnsafe("0::0/0")
 
-func parseCIDRUnsafe(s string) *net.IPNet {
-	_, cidr, _ := net.ParseCIDR(s)
+func parseCIDRUnsafe(s string) netip.Prefix {
+	cidr, _ := netip.ParsePrefix(s)
 	return cidr
 }
 
 // RangerEntry is an interface for insertable entry into a Ranger.
 type RangerEntry interface {
-	Network() net.IPNet
+	Network() netip.Prefix
 }
 
 type basicRangerEntry struct {
-	ipNet net.IPNet
+	ipNet netip.Prefix
 }
 
-func (b *basicRangerEntry) Network() net.IPNet {
+func (b *basicRangerEntry) Network() netip.Prefix {
 	return b.ipNet
 }
 
 // NewBasicRangerEntry returns a basic RangerEntry that only stores the network
 // itself.
-func NewBasicRangerEntry(ipNet net.IPNet) RangerEntry {
+func NewBasicRangerEntry(ipNet netip.Prefix) RangerEntry {
 	return &basicRangerEntry{
-		ipNet: ipNet,
+		ipNet: ipNet, //.Masked(),
 	}
 }
 
 // Ranger is an interface for cidr block containment lookups.
 type Ranger interface {
 	Insert(entry RangerEntry) error
-	Remove(network net.IPNet) (RangerEntry, error)
-	Contains(ip net.IP) (bool, error)
-	ContainingNetworks(ip net.IP) ([]RangerEntry, error)
-	CoveredNetworks(network net.IPNet) ([]RangerEntry, error)
+	Remove(network netip.Prefix) (RangerEntry, error)
+	Contains(ip netip.Addr) (bool, error)
+	ContainingNetworks(ip netip.Addr) ([]RangerEntry, error)
+	CoveredNetworks(network netip.Prefix) ([]RangerEntry, error)
 	Len() int
 }
 

--- a/cidranger_test.go
+++ b/cidranger_test.go
@@ -2,9 +2,9 @@ package cidranger
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/rand"
-	"net"
+	"net/netip"
+	"os"
 	"testing"
 	"time"
 
@@ -58,10 +58,11 @@ func testContainsAgainstBase(t *testing.T, iterations int, ipGen ipGenerator) {
 
 	for i := 0; i < iterations; i++ {
 		nn := ipGen()
-		expected, err := baseRanger.Contains(nn.ToIP())
+		ip := nn.ToIP()
+		expected, err := baseRanger.Contains(ip)
 		assert.NoError(t, err)
 		for _, ranger := range rangers {
-			actual, err := ranger.Contains(nn.ToIP())
+			actual, err := ranger.Contains(ip)
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
 		}
@@ -127,59 +128,59 @@ func testCoversNetworksAgainstBase(t *testing.T, iterations int, netGen networkG
 */
 
 func BenchmarkPCTrieHitIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("52.95.110.1"), NewPCTrieRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("52.95.110.1"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerHitIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("52.95.110.1"), newBruteRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("52.95.110.1"), newBruteRanger())
 }
 
 func BenchmarkPCTrieHitIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("2620:107:300f::36b7:ff81"), NewPCTrieRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("2620:107:300f::36b7:ff81"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerHitIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("2620:107:300f::36b7:ff81"), newBruteRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("2620:107:300f::36b7:ff81"), newBruteRanger())
 }
 
 func BenchmarkPCTrieMissIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("123.123.123.123"), NewPCTrieRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("123.123.123.123"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerMissIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("123.123.123.123"), newBruteRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("123.123.123.123"), newBruteRanger())
 }
 
 func BenchmarkPCTrieHMissIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("2620::ffff"), NewPCTrieRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("2620::ffff"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerMissIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainsUsingAWSRanges(b, net.ParseIP("2620::ffff"), newBruteRanger())
+	benchmarkContainsUsingAWSRanges(b, netip.MustParseAddr("2620::ffff"), newBruteRanger())
 }
 
 func BenchmarkPCTrieHitContainingNetworksIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("52.95.110.1"), NewPCTrieRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("52.95.110.1"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerHitContainingNetworksIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("52.95.110.1"), newBruteRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("52.95.110.1"), newBruteRanger())
 }
 
 func BenchmarkPCTrieHitContainingNetworksIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620:107:300f::36b7:ff81"), NewPCTrieRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("2620:107:300f::36b7:ff81"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerHitContainingNetworksIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620:107:300f::36b7:ff81"), newBruteRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("2620:107:300f::36b7:ff81"), newBruteRanger())
 }
 
 func BenchmarkPCTrieMissContainingNetworksIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("123.123.123.123"), NewPCTrieRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("123.123.123.123"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerMissContainingNetworksIPv4UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("123.123.123.123"), newBruteRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("123.123.123.123"), newBruteRanger())
 }
 
 func BenchmarkPCTrieHMissContainingNetworksIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620::ffff"), NewPCTrieRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("2620::ffff"), NewPCTrieRanger())
 }
 func BenchmarkBruteRangerMissContainingNetworksIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620::ffff"), newBruteRanger())
+	benchmarkContainingNetworksUsingAWSRanges(b, netip.MustParseAddr("2620::ffff"), newBruteRanger())
 }
 
 func BenchmarkNewPathprefixTriev4(b *testing.B) {
@@ -190,14 +191,14 @@ func BenchmarkNewPathprefixTriev6(b *testing.B) {
 	benchmarkNewPathprefixTrie(b, "8000::/24")
 }
 
-func benchmarkContainsUsingAWSRanges(tb testing.TB, nn net.IP, ranger Ranger) {
+func benchmarkContainsUsingAWSRanges(tb testing.TB, nn netip.Addr, ranger Ranger) {
 	configureRangerWithAWSRanges(tb, ranger)
 	for n := 0; n < tb.(*testing.B).N; n++ {
 		ranger.Contains(nn)
 	}
 }
 
-func benchmarkContainingNetworksUsingAWSRanges(tb testing.TB, nn net.IP, ranger Ranger) {
+func benchmarkContainingNetworksUsingAWSRanges(tb testing.TB, nn netip.Addr, ranger Ranger) {
 	configureRangerWithAWSRanges(tb, ranger)
 	for n := 0; n < tb.(*testing.B).N; n++ {
 		ranger.ContainingNetworks(nn)
@@ -205,10 +206,10 @@ func benchmarkContainingNetworksUsingAWSRanges(tb testing.TB, nn net.IP, ranger 
 }
 
 func benchmarkNewPathprefixTrie(b *testing.B, net1 string) {
-	_, ipNet1, _ := net.ParseCIDR(net1)
-	ones, _ := ipNet1.Mask.Size()
+	ipNet1 := netip.MustParsePrefix(net1)
+	ones := ipNet1.Bits()
 
-	n1 := rnet.NewNetwork(*ipNet1)
+	n1 := rnet.NewNetwork(ipNet1)
 	uOnes := uint(ones)
 
 	b.ResetTimer()
@@ -228,16 +229,20 @@ type ipGenerator func() rnet.NetworkNumber
 func randIPv4Gen() rnet.NetworkNumber {
 	return rnet.NetworkNumber{rand.Uint32()}
 }
-func randIPv6Gen() rnet.NetworkNumber {
-	return rnet.NetworkNumber{rand.Uint32(), rand.Uint32(), rand.Uint32(), rand.Uint32()}
-}
+
 func curatedAWSIPv6Gen() rnet.NetworkNumber {
 	randIdx := rand.Intn(len(ipV6AWSRangesIPNets))
 
 	// Randomly generate an IP somewhat near the range.
 	network := ipV6AWSRangesIPNets[randIdx]
-	nn := rnet.NewNetworkNumber(network.IP)
-	ones, bits := network.Mask.Size()
+	nn := rnet.NewNetworkNumber(network.Addr())
+
+	bits := 32
+	addr := network.Addr()
+	if addr.Is6() {
+		bits = 128
+	}
+	ones := network.Bits()
 	zeros := bits - ones
 	nnPartIdx := zeros / rnet.BitsPerUint32
 	nn[nnPartIdx] = rand.Uint32()
@@ -246,9 +251,9 @@ func curatedAWSIPv6Gen() rnet.NetworkNumber {
 
 type networkGenerator func() rnet.Network
 
-func randomIPNetGenFactory(pool []*net.IPNet) networkGenerator {
+func randomIPNetGenFactory(pool []netip.Prefix) networkGenerator {
 	return func() rnet.Network {
-		return rnet.NewNetwork(*pool[rand.Intn(len(pool))])
+		return rnet.NewNetwork(pool[rand.Intn(len(pool))])
 	}
 }
 
@@ -270,11 +275,11 @@ type IPv6Prefix struct {
 }
 
 var awsRanges *AWSRanges
-var ipV4AWSRangesIPNets []*net.IPNet
-var ipV6AWSRangesIPNets []*net.IPNet
+var ipV4AWSRangesIPNets []netip.Prefix
+var ipV6AWSRangesIPNets []netip.Prefix
 
 func loadAWSRanges() *AWSRanges {
-	file, err := ioutil.ReadFile("./testdata/aws_ip_ranges.json")
+	file, err := os.ReadFile("./testdata/aws_ip_ranges.json")
 	if err != nil {
 		panic(err)
 	}
@@ -288,25 +293,23 @@ func loadAWSRanges() *AWSRanges {
 
 func configureRangerWithAWSRanges(tb testing.TB, ranger Ranger) {
 	for _, prefix := range awsRanges.Prefixes {
-		_, network, err := net.ParseCIDR(prefix.IPPrefix)
-		assert.NoError(tb, err)
-		ranger.Insert(NewBasicRangerEntry(*network))
+		network := netip.MustParsePrefix(prefix.IPPrefix)
+		ranger.Insert(NewBasicRangerEntry(network))
 	}
 	for _, prefix := range awsRanges.IPv6Prefixes {
-		_, network, err := net.ParseCIDR(prefix.IPPrefix)
-		assert.NoError(tb, err)
-		ranger.Insert(NewBasicRangerEntry(*network))
+		network := netip.MustParsePrefix(prefix.IPPrefix)
+		ranger.Insert(NewBasicRangerEntry(network))
 	}
 }
 
 func init() {
 	awsRanges = loadAWSRanges()
 	for _, prefix := range awsRanges.IPv6Prefixes {
-		_, network, _ := net.ParseCIDR(prefix.IPPrefix)
+		network := netip.MustParsePrefix(prefix.IPPrefix)
 		ipV6AWSRangesIPNets = append(ipV6AWSRangesIPNets, network)
 	}
 	for _, prefix := range awsRanges.Prefixes {
-		_, network, _ := net.ParseCIDR(prefix.IPPrefix)
+		network := netip.MustParsePrefix(prefix.IPPrefix)
 		ipV4AWSRangesIPNets = append(ipV4AWSRangesIPNets, network)
 	}
 	rand.Seed(time.Now().Unix())

--- a/example/custom-ranger-asn.go
+++ b/example/custom-ranger-asn.go
@@ -9,7 +9,7 @@ package main
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"os"
 
 	"github.com/yl2chen/cidranger"
@@ -17,12 +17,12 @@ import (
 
 // custom structure that conforms to RangerEntry interface
 type customRangerEntry struct {
-	ipNet net.IPNet
+	ipNet netip.Prefix
 	asn   string
 }
 
 // get function for network
-func (b *customRangerEntry) Network() net.IPNet {
+func (b *customRangerEntry) Network() netip.Prefix {
 	return b.ipNet
 }
 
@@ -37,7 +37,7 @@ func (b *customRangerEntry) Asn() string {
 }
 
 // create customRangerEntry object using net and asn
-func newCustomRangerEntry(ipNet net.IPNet, asn string) cidranger.RangerEntry {
+func newCustomRangerEntry(ipNet netip.Prefix, asn string) cidranger.RangerEntry {
 	return &customRangerEntry{
 		ipNet: ipNet,
 		asn:   asn,
@@ -51,14 +51,14 @@ func main() {
 	ranger := cidranger.NewPCTrieRanger()
 
 	// Load sample data using our custom function
-	_, network, _ := net.ParseCIDR("192.168.1.0/24")
-	ranger.Insert(newCustomRangerEntry(*network, "0001"))
+	network := netip.MustParsePrefix("192.168.1.0/24")
+	ranger.Insert(newCustomRangerEntry(network, "0001"))
 
-	_, network, _ = net.ParseCIDR("128.168.1.0/24")
-	ranger.Insert(newCustomRangerEntry(*network, "0002"))
+	network = netip.MustParsePrefix("128.168.1.0/24")
+	ranger.Insert(newCustomRangerEntry(network, "0002"))
 
 	// Check if IP is contained within ranger
-	contains, err := ranger.Contains(net.ParseIP("128.168.1.7"))
+	contains, err := ranger.Contains(netip.MustParseAddr("128.168.1.7"))
 	if err != nil {
 		fmt.Println("ranger.Contains()", err.Error())
 		os.Exit(1)
@@ -67,7 +67,7 @@ func main() {
 
 	// request networks containing this IP
 	ip := "192.168.1.42"
-	entries, err := ranger.ContainingNetworks(net.ParseIP(ip))
+	entries, err := ranger.ContainingNetworks(netip.MustParseAddr(ip))
 	if err != nil {
 		fmt.Println("ranger.ContainingNetworks()", err.Error())
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/yl2chen/cidranger
 
-go 1.13
+go 1.18
+
+require github.com/stretchr/testify v1.6.1
 
 require (
-	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,13 +3,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR moves cidranger from using the IP address/prefix values from the `"net"` module in the Go standard libary to using the equivalents from the newer `"net/netip"` in the standard library. This allows for some code simplification:
* no need to check for invalid underlying `[]byte` lengths or nil pointers
* `netip.Prefix` can be used directly as a map key in bruteranger as opposed to a `net.IPNet`'s `.String()` value
* address comparisons can be done directly with `==`/`!=` as opposed to via `bytes.Equal()`

The tests were updated to use `net/netip`, and run successfully. `TestInsertError` and `TestRemoveError` were removed, as the error they are testing for is impossible to induce with `net/netip`

This is a fairly big update, and since it changes a good chunk of the API, likely warrants a version bump, though I am opening this PR to at least see if this is a change that you are interested in and if you have any changes in mind.
`net/netip` was introduced in 1.18, and, as 1.19 is out now, all officially supported versions of Go (the last two releases) support this, though applications and libraries making use of cidranger would need to be rewritten or at least add wrapper code to handle this, if this version is used.